### PR TITLE
Use GitHub Secrets to store api keys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Create .env file from GitHub Secrets
+        run: |
+          echo "GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}" >> .env
+          echo "FIREBASE_API_KEY=${{ secrets.FIREBASE_API_KEY }}" >> .env
+          echo "FIREBASE_AUTH_DOMAIN=${{ secrets.FIREBASE_AUTH_DOMAIN }}" >> .env
+          echo "FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}" >> .env
+          echo "FIREBASE_STORAGE_BUCKET=${{ secrets.FIREBASE_STORAGE_BUCKET }}" >> .env
+          echo "FIREBASE_MESSAGING_SENDER_ID=${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}" >> .env
+          echo "FIREBASE_APP_ID=${{ secrets.FIREBASE_APP_ID }}" >> .env
+          echo "FIREBASE_MEASUREMENT_ID=${{ secrets.FIREBASE_MEASUREMENT_ID }}" >> .env
+          echo "VITE_GOOGLE_CLIENT_ID=${{ secrets.VITE_GOOGLE_CLIENT_ID }}" >> .env
+          echo "GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}" >> .env
+
       - name: Build
         run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,27 @@ This contains everything you need to run your app locally.
 
 3. Run the app:
    `npm run dev`
+
+## Deployment with GitHub Actions
+
+To deploy this app using GitHub Actions and securely handle environment variables:
+
+1. Go to your repository on GitHub.
+2. Navigate to **Settings → Secrets and variables → Actions**.
+3. Add each environment variable from `.env.example` as a new secret (use the same variable names).
+4. The GitHub Actions workflow will automatically create a `.env` file from these secrets during deployment.
+5. No secrets are ever committed to the repository.
+
+**Required secrets:**
+- GEMINI_API_KEY
+- FIREBASE_API_KEY
+- FIREBASE_AUTH_DOMAIN
+- FIREBASE_PROJECT_ID
+- FIREBASE_STORAGE_BUCKET
+- FIREBASE_MESSAGING_SENDER_ID
+- FIREBASE_APP_ID
+- FIREBASE_MEASUREMENT_ID
+- VITE_GOOGLE_CLIENT_ID
+- GOOGLE_API_KEY
+
+For more details, see `.github/workflows/deploy.yml`.


### PR DESCRIPTION
The GitHub Actions workflow now creates a .env file from repository secrets before building your project. To complete the setup, add each required variable from your .env.example as a secret in your repository's GitHub settings (Settings → Secrets and variables → Actions). This ensures your environment variables are securely injected during deployment and never committed to the repository.