### PR TITLE
Fix: Update Gemini model name to remove preview suffix

### DIFF
--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -161,7 +161,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
           </select>
         </SettingRow>
         
-        <SettingRow label="Disable Thinking (Flash Model)" description="For 'gemini-2.5-flash-preview-04-17': disable thinking for lower latency.">
+        <SettingRow label="Disable Thinking (Flash Model)" description="For 'gemini-2.5-flash': disable thinking for lower latency.">
              <div className="flex items-center h-5">
                 <input id="disableThinking" name="disableThinking" type="checkbox" checked={currentSettings.disableThinking} onChange={handleChange}
                     className="focus:ring-primary-500 h-4 w-4 text-primary-600 border-slate-300 rounded" />

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -54,7 +54,7 @@ export class GeminiService {
       // thinkingConfig will be added conditionally below
     };
 
-    if (GEMINI_MODEL_NAME === "gemini-2.5-flash-preview-04-17") {
+    if (GEMINI_MODEL_NAME === "gemini-2.5-flash") {
         chatCreationConfig.thinkingConfig = settings.disableThinking ? { thinkingBudget: 0 } : undefined;
     }
 


### PR DESCRIPTION
Updated the hardcoded Gemini model name from 'gemini-2.5-flash-preview-04-17' to 'gemini-2.5-flash' in the services and components where it was referenced.

- In `services/geminiService.ts`, the conditional check for enabling the 'thinking' feature now correctly uses the current model name.
- In `components/SettingsView.tsx`, the UI description for the 'Disable Thinking' setting has been updated to reflect the correct model name.